### PR TITLE
allow changing handler impl

### DIFF
--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -1,8 +1,6 @@
 package microerror
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
 
@@ -45,8 +43,7 @@ func (h *ErrgoHandler) Maskf(err error, f string, v ...interface{}) error {
 		return nil
 	}
 
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr := errgo.WithCausef(err, errgo.Cause(err), f, v...)
 	newErr.(*errgo.Err).SetLocation(h.callDepth)
 	return newErr
 }

--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -31,11 +31,15 @@ func NewErrgoHandler(config ErrgoHandlerConfig) *ErrgoHandler {
 }
 
 func (h *ErrgoHandler) New(s string) error {
-	return errgo.New(s)
+	err := errgo.New(s).(*errgo.Err)
+	err.SetLocation(h.callDepth)
+	return err
 }
 
 func (h *ErrgoHandler) Newf(f string, v ...interface{}) error {
-	return errgo.Newf(f, v...)
+	err := errgo.Newf(f, v...).(*errgo.Err)
+	err.SetLocation(h.callDepth)
+	return err
 }
 
 func (h *ErrgoHandler) Cause(err error) error {

--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -30,6 +30,14 @@ func NewErrgoHandler(config ErrgoHandlerConfig) *ErrgoHandler {
 	}
 }
 
+func (h *ErrgoHandler) New(s string) error {
+	return errgo.New(s)
+}
+
+func (h *ErrgoHandler) Newf(f string, v ...interface{}) error {
+	return errgo.Newf(f, v...)
+}
+
 func (h *ErrgoHandler) Cause(err error) error {
 	return errgo.Cause(err)
 }

--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -1,0 +1,38 @@
+package microerror
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+// ErrgoHandler implements Handler interface.
+type ErrgoHandler struct {
+	maskFunc func(err error, allow ...func(error) bool) error
+}
+
+func NewErrgoHandler() *ErrgoHandler {
+	return &ErrgoHandler{
+		maskFunc: errgo.MaskFunc(errgo.Any),
+	}
+}
+
+func (h *ErrgoHandler) Cause(err error) error {
+	return errgo.Cause(err)
+}
+
+func (h *ErrgoHandler) Mask(err error) error {
+	return h.maskFunc(err)
+}
+
+func (h *ErrgoHandler) Maskf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}

--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -4,22 +4,28 @@ import (
 	"github.com/juju/errgo"
 )
 
+type ErrgoHandlerConfig struct {
+	// CallDepth is useful when creating a wrapper for ErrgoHandler. Its
+	// value is used to push stack location and skip wrapping function
+	// location as an origin. The default value is 0.
+	CallDepth int
+}
+
+func DefaultErrgoHandlerConfig() ErrgoHandlerConfig {
+	return ErrgoHandlerConfig{
+		CallDepth: 0,
+	}
+}
+
 // ErrgoHandler implements Handler interface.
 type ErrgoHandler struct {
 	callDepth int
 	maskFunc  func(err error, allow ...func(error) bool) error
 }
 
-func NewErrgoHandler() *ErrgoHandler {
-	return NewErrgoHandlerCallDepth(0)
-}
-
-// NewErrgoHandlerCallDepth is useful when creating a wrapper for ErrgoHandler.
-// The callDepth parameter is used to push stack location and skip wrapping
-// function location as an origin. The default value is 0.
-func NewErrgoHandlerCallDepth(callDepth int) *ErrgoHandler {
+func NewErrgoHandler(config ErrgoHandlerConfig) *ErrgoHandler {
 	return &ErrgoHandler{
-		callDepth: callDepth + 1, // +1 for ErrgoHandler wrapping methods
+		callDepth: config.CallDepth + 1, // +1 for ErrgoHandler wrapping methods
 		maskFunc:  errgo.MaskFunc(errgo.Any),
 	}
 }

--- a/errgo_handler_test.go
+++ b/errgo_handler_test.go
@@ -1,0 +1,9 @@
+package microerror
+
+import "testing"
+
+func TestErrgoHandlerInterface(t *testing.T) {
+	// This will not complie if ErrgoHandler does not fulfill Handler
+	// interface.
+	var _ Handler = NewErrgoHandler()
+}

--- a/errgo_handler_test.go
+++ b/errgo_handler_test.go
@@ -11,11 +11,11 @@ import (
 func TestErrgoHandler_Interface(t *testing.T) {
 	// This will not complie if ErrgoHandler does not fulfill Handler
 	// interface.
-	var _ Handler = NewErrgoHandler()
+	var _ Handler = NewErrgoHandler(DefaultErrgoHandlerConfig())
 }
 
 func TestErrgoHandler_Mask_Nil(t *testing.T) {
-	handler := NewErrgoHandler()
+	handler := NewErrgoHandler(DefaultErrgoHandlerConfig())
 	err := handler.Mask(nil)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -23,7 +23,7 @@ func TestErrgoHandler_Mask_Nil(t *testing.T) {
 }
 
 func TestErrgoHandler_Maskf_Nil(t *testing.T) {
-	handler := NewErrgoHandler()
+	handler := NewErrgoHandler(DefaultErrgoHandlerConfig())
 	err := handler.Maskf(nil, "test annotation")
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -40,7 +40,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 			desc:  "Mask (1)",
 			depth: 1,
 			maskFunc: func(err error) error {
-				h := NewErrgoHandler()
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 				return h.Mask(err)
 			},
 		},
@@ -48,7 +48,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 			desc:  "Mask (3)",
 			depth: 3,
 			maskFunc: func(err error) error {
-				h := NewErrgoHandler()
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 				err = h.Mask(err)
 				err = h.Mask(err)
 				err = h.Mask(err)
@@ -59,7 +59,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 			desc:  "Maskf (3)",
 			depth: 3,
 			maskFunc: func(err error) error {
-				h := NewErrgoHandler()
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 				err = h.Maskf(err, "1")
 				err = h.Maskf(err, "2")
 				err = h.Maskf(err, "3")

--- a/errgo_handler_test.go
+++ b/errgo_handler_test.go
@@ -1,9 +1,73 @@
 package microerror
 
-import "testing"
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
 
-func TestErrgoHandlerInterface(t *testing.T) {
+	"github.com/juju/errgo"
+)
+
+func TestErrgoHandler_Interface(t *testing.T) {
 	// This will not complie if ErrgoHandler does not fulfill Handler
 	// interface.
 	var _ Handler = NewErrgoHandler()
+}
+
+func TestErrgoHandler_Mask_Nil(t *testing.T) {
+	handler := NewErrgoHandler()
+	err := handler.Mask(nil)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestErrgoHandler_Maskf_Nil(t *testing.T) {
+	handler := NewErrgoHandler()
+	err := handler.Maskf(nil, "test annotation")
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestErrgoHandler_Mask_Location(t *testing.T) {
+	handler := NewErrgoHandler()
+
+	err := fmt.Errorf("test")
+
+	err = handler.Mask(err)
+	err = handler.Mask(err)
+	err = handler.Mask(err)
+
+	errgoErr, ok := err.(*errgo.Err)
+	if !ok {
+		t.Fatalf("expected type *errgo.Err, got %T", err)
+	}
+
+	file := filepath.Base(errgoErr.Location().File)
+	wfile := "errgo_handler_test.go"
+	if file != wfile {
+		t.Fatalf("expected  %s, got %s", wfile, file)
+	}
+}
+
+func TestErrgoHandler_Maskf_Location(t *testing.T) {
+	handler := NewErrgoHandler()
+
+	err := fmt.Errorf("test")
+
+	err = handler.Maskf(err, "1")
+	err = handler.Maskf(err, "2")
+	err = handler.Maskf(err, "3")
+
+	errgoErr, ok := err.(*errgo.Err)
+	if !ok {
+		t.Fatalf("expected type *errgo.Err, got %T", err)
+	}
+
+	file := filepath.Base(errgoErr.Location().File)
+	wfile := "errgo_handler_test.go"
+	if file != wfile {
+		t.Fatalf("expected  %s, got %s", wfile, file)
+	}
 }

--- a/errgo_handler_test.go
+++ b/errgo_handler_test.go
@@ -34,21 +34,60 @@ func TestErrgoHandler_Stack(t *testing.T) {
 	tests := []struct {
 		desc     string
 		depth    int
-		maskFunc func(error) error
+		newError func() error
 	}{
 		{
-			desc:  "Mask (1)",
+			desc:  "Mask depth=1 constructor=handler.New",
 			depth: 1,
-			maskFunc: func(err error) error {
+			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
-				return h.Mask(err)
+
+				err := h.New("test")
+				return err
 			},
 		},
 		{
-			desc:  "Mask (3)",
-			depth: 3,
-			maskFunc: func(err error) error {
+			desc:  "Mask depth=2 constructor=handler.New",
+			depth: 2,
+			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
+
+				err := h.New("test")
+				err = h.Mask(err)
+				return err
+			},
+		},
+		{
+			desc:  "Mask/Maskf depth=3 constructor=handler.Newf",
+			depth: 3,
+			newError: func() error {
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
+
+				err := h.Newf("%s", "test")
+				err = h.Mask(err)
+				err = h.Maskf(err, "3")
+				return err
+
+			},
+		},
+		{
+			desc:  "Mask depth=1 constructor=fmt.Errorf",
+			depth: 1,
+			newError: func() error {
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
+
+				err := fmt.Errorf("test")
+				err = h.Mask(err)
+				return err
+			},
+		},
+		{
+			desc:  "Mask depth=3 constructor=fmt.Errorf",
+			depth: 3,
+			newError: func() error {
+				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
+
+				err := fmt.Errorf("test")
 				err = h.Mask(err)
 				err = h.Mask(err)
 				err = h.Mask(err)
@@ -56,10 +95,12 @@ func TestErrgoHandler_Stack(t *testing.T) {
 			},
 		},
 		{
-			desc:  "Maskf (3)",
+			desc:  "Maskf depth=3 constructor=fmt.Errorf",
 			depth: 3,
-			maskFunc: func(err error) error {
+			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
+
+				err := fmt.Errorf("test")
 				err = h.Maskf(err, "1")
 				err = h.Maskf(err, "2")
 				err = h.Maskf(err, "3")
@@ -69,7 +110,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		err := tc.maskFunc(fmt.Errorf("test"))
+		err := tc.newError()
 
 		var depth int
 		for {

--- a/error.go
+++ b/error.go
@@ -3,22 +3,20 @@
 package microerror
 
 var (
-	Default Handler = NewErrgoHandler(DefaultErrgoHandlerConfig())
+	Default Handler = NewErrgoHandler(ErrgoHandlerConfig{
+		CallDepth: 1,
+	})
 )
 
 // New returns a new error with the given error message. It is a drop-in
 // replacement for errors.New from the standard library.
 func New(s string) error {
-	err := Default.New(s)
-	err = hackErrgoCallDepth(err)
-	return err
+	return Default.New(s)
 }
 
 // Newf returns a new error with the given printf-formatted error message.
 func Newf(f string, v ...interface{}) error {
-	err := Default.Newf(f, v...)
-	err = hackErrgoCallDepth(err)
-	return err
+	return Default.Newf(f, v...)
 }
 
 // Cause returns the cause of the given error. If the cause of the err can not
@@ -34,31 +32,12 @@ func Cause(err error) error {
 // source code. Inspecting an masked error shows where the error was passed
 // through within the code base. This is gold for debugging and bug hunting.
 func Mask(err error) error {
-	err = Default.Mask(err)
-	err = hackErrgoCallDepth(err)
-	return err
+	return Default.Mask(err)
 }
 
 // Maskf is like Mask. In addition to that it takes a format string and
 // variadic arguments like fmt.Sprintf. The format string and variadic
 // arguments are used to annotate the given errgo error.
 func Maskf(err error, f string, v ...interface{}) error {
-	err = Default.Maskf(err, f, v...)
-	err = hackErrgoCallDepth(err)
-	return err
-}
-
-type locationer interface {
-	SetLocation(int)
-}
-
-func hackErrgoCallDepth(err error) error {
-	if err == nil {
-		return nil
-	}
-	_, ok := Default.(*ErrgoHandler)
-	if ok {
-		err.(locationer).SetLocation(2)
-	}
-	return err
+	return Default.Maskf(err, f, v...)
 }

--- a/error.go
+++ b/error.go
@@ -3,7 +3,7 @@
 package microerror
 
 var (
-	Default = NewErrgoHandler()
+	Default = NewErrgoHandlerCallDepth(1)
 )
 
 // Cause returns the cause of the given error. If the cause of the err can not

--- a/error.go
+++ b/error.go
@@ -3,7 +3,9 @@
 package microerror
 
 var (
-	Default = NewErrgoHandlerCallDepth(1)
+	Default = NewErrgoHandler(ErrgoHandlerConfig{
+		CallDepth: 1,
+	})
 )
 
 // Cause returns the cause of the given error. If the cause of the err can not

--- a/error.go
+++ b/error.go
@@ -3,20 +3,22 @@
 package microerror
 
 var (
-	Default Handler = NewErrgoHandler(ErrgoHandlerConfig{
-		CallDepth: 1,
-	})
+	Default Handler = NewErrgoHandler(DefaultErrgoHandlerConfig())
 )
 
 // New returns a new error with the given error message. It is a drop-in
 // replacement for errors.New from the standard library.
 func New(s string) error {
-	return Default.New(s)
+	err := Default.New(s)
+	err = hackErrgoCallDepth(err)
+	return err
 }
 
 // Newf returns a new error with the given printf-formatted error message.
 func Newf(f string, v ...interface{}) error {
-	return Default.Newf(f, v...)
+	err := Default.Newf(f, v...)
+	err = hackErrgoCallDepth(err)
+	return err
 }
 
 // Cause returns the cause of the given error. If the cause of the err can not
@@ -32,12 +34,31 @@ func Cause(err error) error {
 // source code. Inspecting an masked error shows where the error was passed
 // through within the code base. This is gold for debugging and bug hunting.
 func Mask(err error) error {
-	return Default.Mask(err)
+	err = Default.Mask(err)
+	err = hackErrgoCallDepth(err)
+	return err
 }
 
 // Maskf is like Mask. In addition to that it takes a format string and
 // variadic arguments like fmt.Sprintf. The format string and variadic
 // arguments are used to annotate the given errgo error.
 func Maskf(err error, f string, v ...interface{}) error {
-	return Default.Maskf(err, f, v...)
+	err = Default.Maskf(err, f, v...)
+	err = hackErrgoCallDepth(err)
+	return err
+}
+
+type locationer interface {
+	SetLocation(int)
+}
+
+func hackErrgoCallDepth(err error) error {
+	if err == nil {
+		return nil
+	}
+	_, ok := Default.(*ErrgoHandler)
+	if ok {
+		err.(locationer).SetLocation(2)
+	}
+	return err
 }

--- a/error.go
+++ b/error.go
@@ -8,6 +8,17 @@ var (
 	})
 )
 
+// New returns a new error with the given error message. It is a drop-in
+// replacement for errors.New from the standard library.
+func New(s string) error {
+	return Default.New(s)
+}
+
+// Newf returns a new error with the given printf-formatted error message.
+func Newf(f string, v ...interface{}) error {
+	return Default.Newf(f, v...)
+}
+
 // Cause returns the cause of the given error. If the cause of the err can not
 // be found it returns the err itself.
 //

--- a/error.go
+++ b/error.go
@@ -28,13 +28,3 @@ func Mask(err error) error {
 func Maskf(err error, f string, v ...interface{}) error {
 	return Default.Maskf(err, f, v...)
 }
-
-// MaskAny is an alias for Mask. It is there for the backward compatibility.
-func MaskAny(err error) error {
-	return Default.Mask(err)
-}
-
-// MaskAnyf is an for MaskAnyf. It is there for backward compatibility.
-func MaskAnyf(err error, f string, v ...interface{}) error {
-	return Default.Maskf(err, f, v...)
-}

--- a/error.go
+++ b/error.go
@@ -3,7 +3,7 @@
 package microerror
 
 var (
-	Default Handler = NewErrgoHandler(ErrgoHandlerConfig{
+	handler Handler = NewErrgoHandler(ErrgoHandlerConfig{
 		CallDepth: 1,
 	})
 )
@@ -11,12 +11,12 @@ var (
 // New returns a new error with the given error message. It is a drop-in
 // replacement for errors.New from the standard library.
 func New(s string) error {
-	return Default.New(s)
+	return handler.New(s)
 }
 
 // Newf returns a new error with the given printf-formatted error message.
 func Newf(f string, v ...interface{}) error {
-	return Default.Newf(f, v...)
+	return handler.Newf(f, v...)
 }
 
 // Cause returns the cause of the given error. If the cause of the err can not
@@ -25,19 +25,19 @@ func Newf(f string, v ...interface{}) error {
 // Cause is the usual way to diagnose errors that may have been wrapped by Mask
 // or Maskf.
 func Cause(err error) error {
-	return Default.Cause(err)
+	return handler.Cause(err)
 }
 
 // Mask is a simple error masker. Masked errors act as tracers within the
 // source code. Inspecting an masked error shows where the error was passed
 // through within the code base. This is gold for debugging and bug hunting.
 func Mask(err error) error {
-	return Default.Mask(err)
+	return handler.Mask(err)
 }
 
 // Maskf is like Mask. In addition to that it takes a format string and
 // variadic arguments like fmt.Sprintf. The format string and variadic
 // arguments are used to annotate the given errgo error.
 func Maskf(err error, f string, v ...interface{}) error {
-	return Default.Maskf(err, f, v...)
+	return handler.Maskf(err, f, v...)
 }

--- a/error.go
+++ b/error.go
@@ -2,38 +2,39 @@
 // and efficient error handling.
 package microerror
 
-import (
-	"fmt"
-
-	"github.com/juju/errgo"
-)
-
 var (
-	// MaskAny is a simple error masker. Masked errors act as tracers within the
-	// source code. Inspecting an masked error shows where the error was passed
-	// through within the code base. This is gold for debugging and bug huntin.
-	MaskAny = errgo.MaskFunc(errgo.Any)
+	Default = NewErrgoHandler()
 )
 
-// MaskAnyf is like MaskAny. In addition to that it takes a format string and
-// variadic arguments like fmt.Sprintf. The format string and variadic arguments
-// are used to annotate the given errgo error.
-func MaskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
+// Cause returns the cause of the given error. If the cause of the err can not
+// be found it returns the err itself.
+//
+// Cause is the usual way to diagnose errors that may have been wrapped by Mask
+// or Maskf.
+func Cause(err error) error {
+	return Default.Cause(err)
 }
 
-// PanicOnError panics in case the given error is not nil. Otherwise it will do
-// nothing.
-func PanicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
+// Mask is a simple error masker. Masked errors act as tracers within the
+// source code. Inspecting an masked error shows where the error was passed
+// through within the code base. This is gold for debugging and bug hunting.
+func Mask(err error) error {
+	return Default.Mask(err)
+}
+
+// Maskf is like Mask. In addition to that it takes a format string and
+// variadic arguments like fmt.Sprintf. The format string and variadic
+// arguments are used to annotate the given errgo error.
+func Maskf(err error, f string, v ...interface{}) error {
+	return Default.Maskf(err, f, v...)
+}
+
+// MaskAny is an alias for Mask. It is there for the backward compatibility.
+func MaskAny(err error) error {
+	return Default.Mask(err)
+}
+
+// MaskAnyf is an for MaskAnyf. It is there for backward compatibility.
+func MaskAnyf(err error, f string, v ...interface{}) error {
+	return Default.Maskf(err, f, v...)
 }

--- a/error.go
+++ b/error.go
@@ -3,7 +3,7 @@
 package microerror
 
 var (
-	Default = NewErrgoHandler(ErrgoHandlerConfig{
+	Default Handler = NewErrgoHandler(ErrgoHandlerConfig{
 		CallDepth: 1,
 	})
 )

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,61 @@
+package microerror
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/juju/errgo"
+)
+
+func TestMask_Nil(t *testing.T) {
+	err := Mask(nil)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestMaskf_Nil(t *testing.T) {
+	err := Maskf(nil, "test annotation")
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestMask_Location(t *testing.T) {
+	err := fmt.Errorf("test")
+
+	err = Mask(err)
+	err = Mask(err)
+	err = Mask(err)
+
+	errgoErr, ok := err.(*errgo.Err)
+	if !ok {
+		t.Fatalf("expected type *errgo.Err, got %T", err)
+	}
+
+	file := filepath.Base(errgoErr.Location().File)
+	wfile := "error_test.go"
+	if file != wfile {
+		t.Fatalf("expected  %s, got %s", wfile, file)
+	}
+}
+
+func TestMaskf_Location(t *testing.T) {
+	err := fmt.Errorf("test")
+
+	err = Maskf(err, "1")
+	err = Maskf(err, "2")
+	err = Maskf(err, "3")
+
+	errgoErr, ok := err.(*errgo.Err)
+	if !ok {
+		t.Fatalf("expected type *errgo.Err, got %T", err)
+	}
+
+	file := filepath.Base(errgoErr.Location().File)
+	wfile := "error_test.go"
+	if file != wfile {
+		t.Fatalf("expected  %s, got %s", wfile, file)
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -26,19 +26,50 @@ func TestStack(t *testing.T) {
 	tests := []struct {
 		desc     string
 		depth    int
-		maskFunc func(error) error
+		newError func() error
 	}{
 		{
-			desc:  "Mask (1)",
+			desc:  "Mask depth=1 constructor=New",
 			depth: 1,
-			maskFunc: func(err error) error {
-				return Mask(err)
+			newError: func() error {
+				err := New("test")
+				return err
 			},
 		},
 		{
-			desc:  "Mask (3)",
+			desc:  "Mask depth=2 constructor=New",
+			depth: 2,
+			newError: func() error {
+				err := New("test")
+				err = Mask(err)
+				return err
+			},
+		},
+		{
+			desc:  "Mask/Maskf depth=3 constructor=Newf",
 			depth: 3,
-			maskFunc: func(err error) error {
+			newError: func() error {
+				err := Newf("%s", "test")
+				err = Mask(err)
+				err = Maskf(err, "3")
+				return err
+
+			},
+		},
+		{
+			desc:  "Mask depth=1 constructor=fmt.Errorf",
+			depth: 1,
+			newError: func() error {
+				err := fmt.Errorf("test")
+				err = Mask(err)
+				return err
+			},
+		},
+		{
+			desc:  "Mask depth=3 constructor=fmt.Errorf",
+			depth: 3,
+			newError: func() error {
+				err := fmt.Errorf("test")
 				err = Mask(err)
 				err = Mask(err)
 				err = Mask(err)
@@ -46,9 +77,10 @@ func TestStack(t *testing.T) {
 			},
 		},
 		{
-			desc:  "Maskf (3)",
+			desc:  "Maskf depth=3 constructor=fmt.Errorf",
 			depth: 3,
-			maskFunc: func(err error) error {
+			newError: func() error {
+				err := fmt.Errorf("test")
 				err = Maskf(err, "1")
 				err = Maskf(err, "2")
 				err = Maskf(err, "3")
@@ -58,7 +90,7 @@ func TestStack(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		err := tc.maskFunc(fmt.Errorf("test"))
+		err := tc.newError()
 
 		var depth int
 		for {

--- a/handler.go
+++ b/handler.go
@@ -1,6 +1,14 @@
 package microerror
 
 type Handler interface {
+	// New returns a new error with the given error message. It is
+	// a drop-in replacement for errors.New from the standard library.
+	New(s string) error
+
+	// Newf returns a new error with the given printf-formatted error
+	// message.
+	Newf(f string, v ...interface{}) error
+
 	// Cause returns the cause of the given error. If the cause of the err can not
 	// be found it returns the err itself.
 	//
@@ -15,6 +23,6 @@ type Handler interface {
 
 	// Maskf is like Mask. In addition to that it takes a format string and
 	// variadic arguments like fmt.Sprintf. The format string and variadic
-	// arguments are used to annotate the given errgo error.
+	// arguments are used to annotate the given error.
 	Maskf(err error, f string, v ...interface{}) error
 }

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,20 @@
+package microerror
+
+type Handler interface {
+	// Cause returns the cause of the given error. If the cause of the err can not
+	// be found it returns the err itself.
+	//
+	// Cause is the usual way to diagnose errors that may have been wrapped by Mask
+	// or Maskf.
+	Cause(err error) error
+
+	// Mask is a simple error masker. Masked errors act as tracers within the
+	// source code. Inspecting an masked error shows where the error was passed
+	// through within the code base. This is gold for debugging and bug hunting.
+	Mask(err error) error
+
+	// Maskf is like Mask. In addition to that it takes a format string and
+	// variadic arguments like fmt.Sprintf. The format string and variadic
+	// arguments are used to annotate the given errgo error.
+	Maskf(err error, f string, v ...interface{}) error
+}


### PR DESCRIPTION
* create Handler interface
* create global Default implementation which can be configured by user
* add Mask and Maskf functions (remove Any from names)
* add Cause func to not force using projects to import external package
* remove PanicOnError
* add errors constructors (New, Newf)

---

This takes `HttpClient` approach of having global `Default` var which can be customised to the user needs.

We want to have that wrapper to be able to switch masking implementation easily. If we care about that, we should also give freedom to our library users.

---

I'm fishing for 2 LGTMs here.

Towards https://github.com/giantswarm/microkit/issues/73