### PR TITLE
create errors without location

### DIFF
--- a/errgo_handler.go
+++ b/errgo_handler.go
@@ -1,6 +1,9 @@
 package microerror
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/juju/errgo"
 )
 
@@ -31,15 +34,11 @@ func NewErrgoHandler(config ErrgoHandlerConfig) *ErrgoHandler {
 }
 
 func (h *ErrgoHandler) New(s string) error {
-	err := errgo.New(s).(*errgo.Err)
-	err.SetLocation(h.callDepth)
-	return err
+	return errors.New(s)
 }
 
 func (h *ErrgoHandler) Newf(f string, v ...interface{}) error {
-	err := errgo.Newf(f, v...).(*errgo.Err)
-	err.SetLocation(h.callDepth)
-	return err
+	return fmt.Errorf(f, v...)
 }
 
 func (h *ErrgoHandler) Cause(err error) error {

--- a/errgo_handler_test.go
+++ b/errgo_handler_test.go
@@ -38,7 +38,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 	}{
 		{
 			desc:  "Mask depth=1 constructor=handler.New",
-			depth: 1,
+			depth: 0,
 			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 
@@ -48,7 +48,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 		},
 		{
 			desc:  "Mask depth=2 constructor=handler.New",
-			depth: 2,
+			depth: 1,
 			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 
@@ -59,7 +59,7 @@ func TestErrgoHandler_Stack(t *testing.T) {
 		},
 		{
 			desc:  "Mask/Maskf depth=3 constructor=handler.Newf",
-			depth: 3,
+			depth: 2,
 			newError: func() error {
 				h := NewErrgoHandler(DefaultErrgoHandlerConfig())
 

--- a/error_test.go
+++ b/error_test.go
@@ -30,7 +30,7 @@ func TestStack(t *testing.T) {
 	}{
 		{
 			desc:  "Mask depth=1 constructor=New",
-			depth: 1,
+			depth: 0,
 			newError: func() error {
 				err := New("test")
 				return err
@@ -38,7 +38,7 @@ func TestStack(t *testing.T) {
 		},
 		{
 			desc:  "Mask depth=2 constructor=New",
-			depth: 2,
+			depth: 1,
 			newError: func() error {
 				err := New("test")
 				err = Mask(err)
@@ -47,7 +47,7 @@ func TestStack(t *testing.T) {
 		},
 		{
 			desc:  "Mask/Maskf depth=3 constructor=Newf",
-			depth: 3,
+			depth: 2,
 			newError: func() error {
 				err := Newf("%s", "test")
 				err = Mask(err)


### PR DESCRIPTION
In our services we never create errors in place. We always create them
in error.go file in the package. Then when a function responds with
error it uses an error instance from error.go.

There is no reason to put location in that error, as it adds only
a clutter. We should be able to resolve only first Mask call.

Still this is easy to change if we decide otherwise.