### PR TITLE
fixes printing new error type

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,8 +1,6 @@
 package microerror
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // Error is a predefined error structure whose purpose is to act as container
 // for meta information associated to a specific error. The specific error type
@@ -11,7 +9,7 @@ import (
 // a usual error defined, along with its matcher. This error is the root cause
 // once emitted during runtime.
 //
-//     var notEnoughWorkersError = microerror.Error{
+//     var notEnoughWorkersError = &microerror.Error{
 //         Desc: "The amount of requested guest cluster workers exceeds the available number of host cluster nodes.",
 //         Docs: "https://github.com/giantswarm/ops-recipes/blob/master/349-not-enough-workers.md",
 //         Kind: "notEnoughWorkersError",
@@ -28,39 +26,22 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return e.Desc
+	if e.Desc == "" {
+		return e.String()
+	} else {
+		return e.Desc
+	}
 }
 
 func (e *Error) GoString() string {
 	return e.String()
 }
 
-func (e *Error) MarshalJSON() ([]byte, error) {
-	b, err := json.Marshal(e)
-	if err != nil {
-		return nil, Mask(err)
-	}
-
-	return b, nil
-}
-
 func (e *Error) String() string {
-	b, err := e.MarshalJSON()
+	b, err := json.Marshal(e)
 	if err != nil {
 		panic(err)
 	}
 
 	return string(b)
-}
-
-func (e *Error) UnmarshalJSON(b []byte) error {
-	var c Error
-	err := json.Unmarshal(b, &c)
-	if err != nil {
-		return Mask(err)
-	}
-
-	*e = c
-
-	return nil
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,26 @@
+package microerror
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func Test_Error(t *testing.T) {
+	var err error
+
+	testError := &Error{
+		Kind: "testError",
+	}
+
+	err = Mask(testError)
+
+	got := fmt.Sprintf("%#v\n", err)
+	r, err := regexp.Compile(`[.* {{"desc":"","docs":"","kind":"testError"}}]`)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+	if !r.MatchString(got) {
+		t.Fatalf("expected %#v got %#v", true, false)
+	}
+}


### PR DESCRIPTION
Right now the printed errors are empty. 

```
[{/Users/xh3b4sd/go/src/github.com/giantswarm/microerror/error_test.go:15: } {}]
```

This PR fixes the issue in a rather hacky way. Once we moved all errors to our own type we can work on the stack magic and fix this when getting rid of the `errgo` stuff. 
```
[{/Users/xh3b4sd/go/src/github.com/giantswarm/microerror/error_test.go:15: } {{"desc":"","docs":"","kind":"testError"}}]
```