### PR TITLE
adds deprecation notes to interface

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -3,10 +3,16 @@ package microerror
 type Handler interface {
 	// New returns a new error with the given error message. It is
 	// a drop-in replacement for errors.New from the standard library.
+	//
+	// NOTE deprecated
+	//
 	New(s string) error
 
 	// Newf returns a new error with the given printf-formatted error
 	// message.
+	//
+	// NOTE deprecated
+	//
 	Newf(f string, v ...interface{}) error
 
 	// Cause returns the cause of the given error. If the cause of the err can not


### PR DESCRIPTION
Since we are going to use our custom error structure and it is initialized literally without constructor we can deprecate them. Further implementations do not need to comply with them. 