### PR TITLE
add Stack function

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -1,0 +1,24 @@
+package microerror
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+// Stack prints the error with the stack if its argument is underlying
+// microerror error or result of Error function otherwise. Its main purpose is
+// to be used for a value for "stack" micrologger key.
+//
+// Example:
+//
+//	logger.LogCtx(ctx, "level", "error", "message", "failed to do a thing", "stack", microerror.Stack(err))
+//
+func Stack(err error) string {
+	switch err.(type) {
+	case *errgo.Err:
+		return fmt.Sprintf("%#v", err)
+	default:
+		return err.Error()
+	}
+}

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -2,40 +2,44 @@ package microerror
 
 import (
 	"errors"
-	"go/build"
-	"reflect"
+	"regexp"
 	"strconv"
 	"testing"
 )
 
 func Test_Stack(t *testing.T) {
 	testCases := []struct {
-		name          string
-		inputErr      error
-		expectedStack string
+		name                string
+		inputErr            error
+		expectedStackRegexp string
 	}{
 		{
-			name:          "case 0: annotated microerror error",
-			inputErr:      Maskf(&Error{Kind: "testKind"}, "annotation"),
-			expectedStack: "[{" + build.Default.GOPATH + "/src/github.com/giantswarm/microerror/funcs_test.go:19: annotation} {test kind}]",
+			name:                "case 0: annotated microerror error",
+			inputErr:            Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedStackRegexp: `^\[\{[a-zA-Z_/-]*/src/github.com/giantswarm/microerror/funcs_test.go:\d+: annotation\} \{test kind\}\]$`,
 		},
 		{
-			name:          "case 1: non annotated microerror error",
-			inputErr:      &Error{Kind: "testKind"},
-			expectedStack: "test kind",
+			name:                "case 1: non annotated microerror error",
+			inputErr:            &Error{Kind: "testKind"},
+			expectedStackRegexp: "^test kind$",
 		},
 		{
-			name:          "case 2: external error",
-			inputErr:      errors.New("external error"),
-			expectedStack: "external error",
+			name:                "case 2: external error",
+			inputErr:            errors.New("external error"),
+			expectedStackRegexp: "^external error$",
 		},
 	}
 
 	for i, tc := range testCases {
+		re, err := regexp.Compile(tc.expectedStackRegexp)
+		if err != nil {
+			t.Fatalf("err = %q, want nil", Stack(err))
+		}
+
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			stack := Stack(tc.inputErr)
-			if !reflect.DeepEqual(stack, tc.expectedStack) {
-				t.Fatalf("stack = %q, want %q", stack, tc.expectedStack)
+			if !re.MatchString(stack) {
+				t.Fatalf("stack = %q, want matching regexp %#q", stack, tc.expectedStackRegexp)
 			}
 		})
 	}

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -1,0 +1,41 @@
+package microerror
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func Test_Stack(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputErr      error
+		expectedStack string
+	}{
+		{
+			name:          "case 0: annotated microerror error",
+			inputErr:      Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedStack: "[{/Users/pawel/go/src/github.com/giantswarm/microerror/funcs_test.go:18: annotation} {test kind}]",
+		},
+		{
+			name:          "case 1: non annotated microerror error",
+			inputErr:      &Error{Kind: "testKind"},
+			expectedStack: "test kind",
+		},
+		{
+			name:          "case 2: external error",
+			inputErr:      errors.New("external error"),
+			expectedStack: "external error",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			stack := Stack(tc.inputErr)
+			if !reflect.DeepEqual(stack, tc.expectedStack) {
+				t.Fatalf("stack = %q, want %q", stack, tc.expectedStack)
+			}
+		})
+	}
+}

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -2,6 +2,7 @@ package microerror
 
 import (
 	"errors"
+	"go/build"
 	"reflect"
 	"strconv"
 	"testing"
@@ -16,7 +17,7 @@ func Test_Stack(t *testing.T) {
 		{
 			name:          "case 0: annotated microerror error",
 			inputErr:      Maskf(&Error{Kind: "testKind"}, "annotation"),
-			expectedStack: "[{/go/src/github.com/giantswarm/microerror/funcs_test.go:18: annotation} {test kind}]",
+			expectedStack: "[{" + build.Default.GOPATH + "/src/github.com/giantswarm/microerror/funcs_test.go:19: annotation} {test kind}]",
 		},
 		{
 			name:          "case 1: non annotated microerror error",

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -16,7 +16,7 @@ func Test_Stack(t *testing.T) {
 		{
 			name:          "case 0: annotated microerror error",
 			inputErr:      Maskf(&Error{Kind: "testKind"}, "annotation"),
-			expectedStack: "[{/Users/pawel/go/src/github.com/giantswarm/microerror/funcs_test.go:18: annotation} {test kind}]",
+			expectedStack: "[{/go/src/github.com/giantswarm/microerror/funcs_test.go:18: annotation} {test kind}]",
 		},
 		{
 			name:          "case 1: non annotated microerror error",


### PR DESCRIPTION
This is work towards debugging failed route53-manager errors.

It often happens that we print third party error which has a pointers in
it then we can have useless output like:

```
E 06/05 09:55:10 failed to update target stack `cluster-no6h7-guest-recordsets` | route53-manager/pkg/recordset/recordset.go:378 | stack=&awserr.requestError{awsError:(*awserr.baseError)(0xc00056c940), statusCode:400, requestID:"01bdc5cd-8778-11e9-a07f-ed66816531c5"}
```

Using `"stack", microerror.Stack(err)` instead of
`"stack", fmt.Sprintf("%#v", err)` in our logs should solve the issue.