### PR TITLE
Add function to return Error.Desc

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -25,13 +25,14 @@ func Stack(err error) string {
 	}
 }
 
+// Desc returns the description of a microerror.
 func Desc(err error) string {
 	c := Cause(err)
 	switch c.(type) {
 	case nil:
 		return ""
-	case Error:
-		e, ok := c.(Error)
+	case *Error:
+		e, ok := c.(*Error)
 		if ok {
 			return e.Desc
 		}

--- a/funcs.go
+++ b/funcs.go
@@ -25,7 +25,7 @@ func Stack(err error) string {
 	}
 }
 
-// Desc returns the description of a microerror.
+// Desc returns the description of a microerror.Error.
 func Desc(err error) string {
 	c := Cause(err)
 	switch c.(type) {

--- a/funcs.go
+++ b/funcs.go
@@ -24,3 +24,19 @@ func Stack(err error) string {
 		return err.Error()
 	}
 }
+
+func Desc(err error) string {
+	c := Cause(err)
+	switch c.(type) {
+	case nil:
+		return ""
+	case Error:
+		e, ok := c.(Error)
+		if ok {
+			return e.Desc
+		}
+		return ""
+	default:
+		return ""
+	}
+}

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -49,3 +49,41 @@ func Test_Stack(t *testing.T) {
 		})
 	}
 }
+
+func Test_Desc(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputErr     error
+		expectedDesc string
+	}{
+		{
+			name:         "case 0: microerror without Desc",
+			inputErr:     Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 1: microerror with Desc",
+			inputErr:     &Error{Kind: "testKind", Desc: "test description"},
+			expectedDesc: "test description",
+		},
+		{
+			name:         "case 2: external error",
+			inputErr:     errors.New("external error"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 3: nil",
+			inputErr:     nil,
+			expectedDesc: "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			desc := Desc(tc.inputErr)
+			if desc != tc.expectedDesc {
+				t.Fatalf("desc = %q, expected %q", desc, tc.expectedDesc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This provides a convenient way to fetch the `Desc` property of an Error.