### PR TITLE
release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/giantswarm/microerror/tree/master
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0


### PR DESCRIPTION
I want to make a release as announced here https://gigantic.slack.com/archives/C04TGHDEF/p1580734612042400

> After some discussions and thinking I've decided to release microerror v0.1.0 which would be the tip of the current master. Then I'd like to release v0.2.0 including changes from https://github.com/giantswarm/microerror/pull/22. This is to make migrations less annoying. The plan is to move more or less everything to v0.2.0 with gomodules. I think we can do releases to microerror manually because this stuff doesn't change very often. Shout at me if you think it's a bad idea or you'd like to discuss it in general (I'd suggest making a quick call).

## Checklist

- [x] Update changelog in CHANGELOG.md.