### PR TITLE
Make it compatible with sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new StackTrace public method to expose stack traces. Compliant with Sentry.
+- Make masked error compliant with Sentry.
 
 ## [0.2.1] 2020-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new StackTrace public method to expose stack traces. Compliant with Sentry.
+
 ## [0.2.1] 2020-07-24
 
 ### Added

--- a/microerror.go
+++ b/microerror.go
@@ -47,12 +47,13 @@ func Mask(err error) error {
 }
 
 func mask(err error) error {
-	_, file, line, _ := runtime.Caller(2)
+	pc, file, line, _ := runtime.Caller(2)
 
 	return &stackedError{
 		stackEntry: StackEntry{
 			File: file,
 			Line: line,
+			PC:   pc,
 		},
 		underlying: err,
 	}

--- a/types.go
+++ b/types.go
@@ -101,7 +101,7 @@ func (e *stackedError) Error() string {
 // all the fields to JSONError and finally marshals it using standard
 // json.Marshal call.
 func (e *stackedError) MarshalJSON() ([]byte, error) {
-	stack := e.extractStackTrace()
+	stack := createStackTrace(e)
 
 	var eerr *Error
 	var annotation string

--- a/types.go
+++ b/types.go
@@ -136,7 +136,7 @@ func (e *stackedError) MarshalJSON() ([]byte, error) {
 }
 
 func (e *stackedError) StackTrace() []uintptr {
-	stack := e.extractStackTrace()
+	stack := createStackTrace(e)
 
 	var pcs []uintptr
 	for _, e := range stack {

--- a/types.go
+++ b/types.go
@@ -38,7 +38,7 @@ type JSONError struct {
 type StackEntry struct {
 	File string  `json:"file"`
 	Line int     `json:"line"`
-	PC   uintptr `json:"pc"`
+	PC   uintptr `json:"-"`
 }
 
 type annotatedError struct {

--- a/types.go
+++ b/types.go
@@ -149,19 +149,3 @@ func (e *stackedError) StackTrace() []uintptr {
 func (e *stackedError) Unwrap() error {
 	return e.underlying
 }
-
-func (e *stackedError) extractStackTrace() []StackEntry {
-	var stack = []StackEntry{
-		e.stackEntry,
-	}
-	{
-		underlying := e.underlying
-		var serr *stackedError
-		for errors.As(underlying, &serr) {
-			stack = append([]StackEntry{serr.stackEntry}, stack...)
-			underlying = serr.underlying
-		}
-	}
-
-	return stack
-}


### PR DESCRIPTION
This PR exposes stack traces in the stackedError type in a way that Sentry (sentry.io) understands.
This will help us send meaningful errors to sentry if we want to.