### PR TITLE
Add vulnerability-check workflow (pilot for merge-queue nancy scan)

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -1,0 +1,21 @@
+name: vulnerability-check
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
+
+permissions: {}
+
+jobs:
+  nancy:
+    uses: giantswarm/github-workflows/.github/workflows/vulnerability-check.yaml@main
+    permissions:
+      contents: read
+    secrets:
+      NANCY_USER: ${{ secrets.NANCY_USER }}
+      NANCY_TOKEN: ${{ secrets.NANCY_TOKEN }}
+      OSSI_OSSINDEXURL: ${{ secrets.OSSI_OSSINDEXURL }}


### PR DESCRIPTION
## What

Adds a `vulnerability-check` GitHub Actions workflow that calls the new `github-workflows/vulnerability-check.yaml` reusable workflow on `pull_request` and `merge_group`.

`microerror` is the pilot for moving the blocking nancy scan out of the CircleCI per-build path and into a GitHub merge-queue check.

## Why

Nancy runs in CircleCI (`architect/go-test`) on every build. The authenticated scan volume drove the Sonatype credit overrun that broke CI on `main`. A `merge_group`-triggered check scans the exact commit about to land, **once**, which satisfies the compliance requirement (last merged commit is always scanned) while cutting the redundant per-build scans.

## Sequencing

This PR is **blocked on giantswarm/github-workflows#220** (the reusable workflow must exist on `@main` first).

Deliberately additive: it does **not** yet remove the CircleCI scan, so we can confirm the GHA scan passes green before changing anything. Follow-ups, once this is green:

1. Bump the architect orb (needs giantswarm/architect-orb#844 released) and set `run_nancy: false` in `.circleci/config.yml` to stop double-scanning.
2. Enable the merge queue on `main` and mark this check required (via a repository ruleset).